### PR TITLE
Add ts-expect-error

### DIFF
--- a/src/sdk/SdkContext.tsx
+++ b/src/sdk/SdkContext.tsx
@@ -47,6 +47,7 @@ export const SdkProvider = ({ children }: PropsWithChildren) => {
 
   useEffect(() => {
     if (selectedAccount) {
+      //@ts-expect-error wait update utils
       const sdkInstance = UniqueChain({ baseUrl, account: selectedAccount });
       setSdk(sdkInstance);
     } else {


### PR DESCRIPTION
Right after cloning the Template and ran the code, I encountered this error:

TS2322: Type 'Account' is not assignable to type '{ readonly publicKey: Uint8Array; address: string; prefixedAddress(prefix?: number | undefined): string; sign(message: string | Uint8Array<...>): Uint8Array<...>; verify(message: string | Uint8Array<...>, signature: string | Uint8Array<...>): boolean; signer: { ...; }; } | undefined'.
Type 'Account' is missing the following properties from type '{ readonly publicKey: Uint8Array; address: string; prefixedAddress(prefix?: number | undefined): string; sign(message: string | Uint8Array): Uint8Array<...>; verify(message: string | Uint8Array<...>, signature: string | Uint8Array<...>): boolean; signer: { ...; }; }': publicKey, prefixedAddress, verify

Going back to the history of the code, I noticed the solution is simply reverting the code of the last commit.